### PR TITLE
chore: adjust fzf preview size

### DIFF
--- a/vim/README.md
+++ b/vim/README.md
@@ -6,9 +6,8 @@ A simple [Vim](https://www.vim.org) configuration
 
 This section covers the requirements necessary to install and use the `vim` configuration.
 
-### Common
-
 * [VimPlug](https://github.com/junegunn/vim-plug) - at least `0.14.0`
+* [Bat] (https://github.com/sharkdp/bat) - at least `0.24.0`
 
 ## Installation
 

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -57,11 +57,10 @@ Plug 'vim-scripts/peaksea'
 call plug#end()
 
 " Plugin 'junegunn/fzf' configuration
-let g:fzf_layout = { 'down': '30%' }
-nnoremap <leader>p :FZF --border --preview cat\ {}<CR>
+let g:fzf_layout = { 'down': '40%' }
 nnoremap <leader>s :FZF --border<CR>
 
-let $FZF_DEFAULT_OPTS="--preview-window 'right:57%' --preview 'bat --style=numbers --line-range :300 {}'
+let $FZF_DEFAULT_OPTS="--preview-window 'right:50%' --preview 'bat --style=numbers --color=always --line-range :300 {}'
 			\ --bind ctrl-y:preview-up,ctrl-e:preview-down,
 			\ctrl-b:preview-page-up,ctrl-f:preview-page-down,
 			\ctrl-u:preview-half-page-up,ctrl-d:preview-half-page-down,


### PR DESCRIPTION
This commit adjusts the FZF preview window size to be 1/2 of the screen wide and 40% of the screen high.

Also:
- Include `--color=always` flag of the `bat` params