### PR TITLE
feat(tmux): document `dark-notify` plugin dependency

### DIFF
--- a/tmux/README.md
+++ b/tmux/README.md
@@ -13,6 +13,7 @@ This section covers the requirements necessary to install and use the `tmux` con
 ### Specific
 
 * [urlview](https://github.com/sigpipe/urlview) - Required by the `tmux-urlview` plugin
+* [dark-notify](https://github.com/cormacrelf/dark-notify) - Required by the `erikw/tmux-dark-notify` plugin
 
 ## Resources
 


### PR DESCRIPTION
This PR updates the `tmux` documentation with additional `dark-notify` _plugin_ dependency.